### PR TITLE
Initialize field `constructor` of `Objs.Property` lazily

### DIFF
--- a/libs/core/src/main/java/net/java/html/lib/Objs.java
+++ b/libs/core/src/main/java/net/java/html/lib/Objs.java
@@ -484,13 +484,13 @@ public class Objs extends java.lang.Object {
     public static final class Property<T> {
         private final Objs js;
         private final Class<T> type;
-        private final Constructor<?> constructor;
         private final String property;
+        private Constructor<?> constructor;
+        private boolean constructorInitialized;
 
         private Property(Objs objs, Class<T> type, java.lang.String property) {
             this.js = objs;
             this.type = type;
-            this.constructor = Constructor.find(type);
             this.property = property;
         }
 
@@ -512,7 +512,7 @@ public class Objs extends java.lang.Object {
          */
         public T get() {
             Object raw = getRaw(Objs.$js(js), property);
-            if (raw != null && constructor != null) {
+            if (raw != null && findConstructor()) {
                 raw = constructor.create(raw);
             }
             return type.cast(raw);
@@ -524,6 +524,13 @@ public class Objs extends java.lang.Object {
          */
         public void set(T value) {
             Objs.setRaw(Objs.$js(js), property, Objs.$js(value));
+        }
+
+        private boolean findConstructor() {
+            if (!constructorInitialized) {
+                constructor = Constructor.find(type);
+            }
+            return constructor != null;
         }
     }
 }


### PR DESCRIPTION
`Constructor.find(Class)` is a relatively slow operation relying on reflection. I suggest calling it on the first call to the getter instead of calling it in the constructor of the `Property` object.

Most `Property` objects are not ever used, since they are created together with their `Objs` object. Consider for example [`CSSStyleDeclaration`](https://www.dukescript.com/javadoc/libs/net/java/html/lib/dom/CSSStyleDeclaration.html). In a typical application, it will be used for one or few properties, but all the `Property` fields must be initialized.